### PR TITLE
Removing '-provisioner' from storage class names

### DIFF
--- a/src/app/helmsman/components/chart-management/chart-management.component.ts
+++ b/src/app/helmsman/components/chart-management/chart-management.component.ts
@@ -102,11 +102,11 @@ export class ChartManagementComponent implements OnInit {
                             'path': `/${this.projectCtrl.value.name}/galaxy`
                         },
                         'persistence': {
-                            'storageClass': 'nfs-provisioner'
+                            'storageClass': 'nfs'
                         },
                         'postgresql': {
                             'persistence': {
-                                'storageClass': 'ebs-provisioner'
+                                'storageClass': 'ebs'
                             }
                         }
                     };


### PR DESCRIPTION
IMO we should revisit setting any values directly in the UI code, but for now just removing '-provisioner' to fix deployment of the chart through UI in the newest GVL