### PR TITLE
Missing repo_name for Galaxy chart

### DIFF
--- a/src/app/helmsman/components/chart-management/chart-management.component.ts
+++ b/src/app/helmsman/components/chart-management/chart-management.component.ts
@@ -97,6 +97,7 @@ export class ChartManagementComponent implements OnInit {
                 if (charts["galaxy"]) {
                     let newChart = new ProjectChart()
                     newChart.name = 'galaxy';
+                    newChart.repo_name = 'cloudve';
                     newChart.project = this.projectCtrl.value;
                     newChart.values = {
                         'ingress': {


### PR DESCRIPTION
Attempting to fix bug where adding gxy chart from UI results in trying to add `None/galaxy` and fails