### PR TITLE
Removing trailing slash in apps path

### DIFF
--- a/src/app/helmsman/components/chart-management/chart-management.component.ts
+++ b/src/app/helmsman/components/chart-management/chart-management.component.ts
@@ -130,14 +130,14 @@ export class ChartManagementComponent implements OnInit {
         if (values && values['ingress']) {
             if (values['ingress']['access_path']) {
                 // FIXME: Should not be directly accessing DOM elements
-                return `${window.location.origin}${values['ingress']['access_path']}/`;
+                return `${window.location.origin}${values['ingress']['access_path']}`;
             }
             else if (values['ingress']['path']) {
                 // FIXME: Should not be directly accessing DOM elements
-                return `${window.location.origin}${values['ingress']['path']}/`;
+                return `${window.location.origin}${values['ingress']['path']}`;
             }
             else if (values['ingress']['hosts'] && values['ingress']['hosts'][0]['paths']) {
-                return `${window.location.origin}${values['ingress']['hosts'][0]['paths'][0]}/`;
+                return `${window.location.origin}${values['ingress']['hosts'][0]['paths'][0]}`;
             }
         }
         return "";


### PR DESCRIPTION
To redirect to OIDC login, jupyter needs to go to `/project/jupyterhub/oauth_login` (without trailing slash). With the trailing slash, it won't work, thus adding the trailing slash by default to all makes it hard to easily overwrite the access_path through template.